### PR TITLE
Add global search form

### DIFF
--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -1,0 +1,32 @@
+class SearchesController < ApplicationController
+  def show
+    @result_collections = [users, videos, moves]
+  end
+
+  private
+
+  def users
+    CollectionWithName.new(
+      name: "Users",
+      collection: Searcher::Users.new(query).find_results,
+    )
+  end
+
+  def videos
+    CollectionWithName.new(
+      name: "Videos",
+      collection: Searcher::Videos.new(query).find_results,
+    )
+  end
+
+  def moves
+    CollectionWithName.new(
+      name: "Moves",
+      collection: Searcher::Moves.new(query).find_results,
+    )
+  end
+
+  def query
+    params.require(:query)
+  end
+end

--- a/app/models/move.rb
+++ b/app/models/move.rb
@@ -18,4 +18,8 @@ class Move < ApplicationRecord
   def creditted_users
     credits.map(&:user)
   end
+
+  def link_text
+    name
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,6 +26,10 @@ class User < ActiveRecord::Base
     UserWithRatingPermissions.new(self).can_rate?(rateable)
   end
 
+  def link_text
+    "@#{username}"
+  end
+
   def self.without(users)
     where.not(id: users.map(&:id))
   end

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -33,6 +33,10 @@ class Video < ApplicationRecord
     credits.map(&:user)
   end
 
+  def link_text
+    name
+  end
+
   def to_param
     "#{id}-#{name.parameterize}"
   end

--- a/app/objects/collection_with_name.rb
+++ b/app/objects/collection_with_name.rb
@@ -1,0 +1,24 @@
+class CollectionWithName
+  def initialize(name:, collection:)
+    @name = name
+    @collection = collection
+  end
+
+  include Enumerable
+
+  def type_name
+    name
+  end
+
+  def each(&block)
+    collection.each(&block)
+  end
+
+  def has_results?
+    collection.present?
+  end
+
+  private
+
+  attr_reader :name, :collection
+end

--- a/app/objects/searcher/videos.rb
+++ b/app/objects/searcher/videos.rb
@@ -1,0 +1,17 @@
+module Searcher
+  class Videos < Base
+    def find_results
+      super.order(:name)
+    end
+
+    private
+
+    def relation
+      Video
+    end
+
+    def column
+      "name"
+    end
+  end
+end

--- a/app/views/application/_search_form.haml
+++ b/app/views/application/_search_form.haml
@@ -1,0 +1,3 @@
+= form_tag searches_path, method: :get do
+  = text_field_tag "query", nil, placeholder: "Search for users, moves, and videos"
+  = submit_tag "Search"

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -19,6 +19,7 @@
 
       %header
         = link_to image_tag("logo.svg", :class => "main-logo"), root_path
+        = render "search_form"
         = render "buttonbar"
 
       %nav

--- a/app/views/searches/show.haml
+++ b/app/views/searches/show.haml
@@ -1,0 +1,10 @@
+- @result_collections.each do |collection|
+  %h1= collection.type_name
+
+  - if collection.has_results?
+    %ul
+      - collection.each do |object|
+        %li
+          = link_to object.link_text, object
+  - else
+    No results

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,5 +75,7 @@ Rails.application.routes.draw do
   get "instagram", to: "instagram#index"
   get "instagram/oauth/callback", to: "instagram#callback"
 
+  get "/search", as: "searches", to: "searches#show"
+
   root to: "welcome#index"
 end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+feature "search" do
+  scenario "searching for users" do
+    user = create :user, username: "darenyeow"
+
+    visit root_path
+
+    fill_in "query", with: "daren"
+    click_button "Search"
+
+    expect(page).to have_content "Users"
+    expect(page).to have_link "@darenyeow"
+  end
+
+  scenario "searching for moves" do
+    move = create :move, name: "Mocking Bird"
+
+    visit root_path
+
+    fill_in "query", with: "mocking"
+    click_button "Search"
+
+    expect(page).to have_content "Moves"
+    expect(page).to have_link "Mocking Bird"
+  end
+
+  scenario "searching for videos" do
+    create :video, name: "Airtime"
+
+    visit root_path
+
+    fill_in "query", with: "air"
+    click_button "Search"
+
+    expect(page).to have_content "Videos"
+    expect(page).to have_link "Airtime"
+  end
+
+  scenario "when there are no results" do
+    visit root_path
+
+    fill_in "query", with: "air"
+    click_button "Search"
+
+    expect(page).to have_content "No results"
+  end
+end


### PR DESCRIPTION
Fixes #47

Searches for users, moves and videos.

The functionality is there, but probably missing some design.

![screen shot 2016-05-07 at 04 10 52](https://cloud.githubusercontent.com/assets/718941/15089686/b675d076-1409-11e6-9d8d-76354c057844.png)

@bendobos Could pull down this branch and have a look at it?
