### PR TITLE
Env RAILS_REDIS_1_PORT was not defined in web container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ app:
 web:
   extends:
     service: app
+  environment:
+    RAILS_REDIS_1_PORT: 6379
   command: bin/rails s -b 0.0.0.0 -p 3000
   ports:
     - "3000:3000"

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -16,12 +16,14 @@ EOF
   exit
 fi
 
-if [ $(uname) = "Darwin" ]; then
-  echo "---- Making sure docker-machine is running"
-  docker-machine start default || true
+if ! command -v docker > /dev/null; then
+  if [ $(uname) = "Darwin" ]; then
+    echo "---- Making sure docker-machine is running"
+    docker-machine start default || true
 
-  echo "---- Connecting to docker-machine"
-  eval $(docker-machine env default)
+    echo "---- Connecting to docker-machine"
+    eval $(docker-machine env default)
+  fi
 fi
 
 # Build docker instance


### PR DESCRIPTION
And bootstrap script checks if docker is working before using docker-machine

I just copied `if ! command -v docker-compose > /dev/null; then` to check if docker is running, @davidpdrsn, please let me know if it's not the correct way.
