### PR TITLE
Reduce startup time when running tests, making them much faster

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -16,14 +16,6 @@ EOF
   exit
 fi
 
-if [ $(uname) = "Darwin" ]; then
-  echo "---- Making sure docker-machine is running"
-  docker-machine start default || true
-
-  echo "---- Connecting to docker-machine"
-  eval $(docker-machine env default)
-fi
-
 # Build docker instance
 echo "---- Building docker image"
 docker-compose build

--- a/script/build
+++ b/script/build
@@ -7,13 +7,5 @@ rm -rf log/test.log
 touch log/development.log
 touch log/test.log
 
-if [ $(uname) = "Darwin" ]; then
-  echo "---- Making sure docker-machine is running"
-  docker-machine start default || true
-
-  echo "---- Connecting to docker-machine"
-  eval $(docker-machine env default)
-fi
-
 script/migrate
 docker-compose build

--- a/script/console
+++ b/script/console
@@ -1,11 +1,4 @@
 #!/bin/bash
 set -e
 
-if [ $(uname) = "Darwin" ]; then
-  echo "---- Making sure docker-machine is running"
-  docker-machine start default || true
-
-  echo "---- Connecting to docker-machine"
-  eval $(docker-machine env default)
-fi
 docker-compose run web bin/rails console

--- a/script/kill-spring
+++ b/script/kill-spring
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+container_name=$(docker ps | grep spring | tr -s " " | awk '{ print $NF }')
+docker kill $container_name

--- a/script/migrate
+++ b/script/migrate
@@ -1,13 +1,5 @@
 #!/bin/bash
 set -e
 
-if [ $(uname) = "Darwin" ]; then
-  echo "---- Making sure docker-machine is running"
-  docker-machine start default || true
-
-  echo "---- Connecting to docker-machine"
-  eval $(docker-machine env default)
-fi
-
 docker-compose run web bin/rake db:migrate RAILS_ENV=development
 docker-compose run web bin/rake db:migrate RAILS_ENV=test

--- a/script/server
+++ b/script/server
@@ -9,12 +9,4 @@ rm -rf log/test.log
 touch log/development.log
 touch log/test.log
 
-if [ $(uname) = "Darwin" ]; then
-  echo "---- Making sure docker-machine is running"
-  docker-machine start default || true
-
-  echo "---- Connecting to docker-machine"
-  eval $(docker-machine env default)
-fi
-
 docker-compose up $@

--- a/script/start-spring
+++ b/script/start-spring
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+bin/rspec spec/lib/active_record_decorator_spec.rb
+tail -f /dev/null

--- a/script/test
+++ b/script/test
@@ -1,20 +1,11 @@
 #!/bin/bash
 set -e
 
-if [ $(uname) = "Darwin" ]; then
-  echo "---- Making sure docker-machine is running"
-  docker-machine start default || true
-
-  echo "---- Connecting to docker-machine"
-  eval $(docker-machine env default)
+if !(docker ps | grep spring > /dev/null); then
+  echo "Starting spring container"
+  docker-compose run -d web script/start-spring
 fi
 
-if $(docker ps | grep 'web' > /dev/null); then
-  echo "--- Running with docker"
-
-  echo "--- Running the tests"
-  docker-compose run web bin/rspec $@
-else
-  echo "Docker isn't running"
-  exit 1
-fi
+container_name=$(docker ps | grep spring | tr -s " " | awk '{ print $NF }')
+echo "Running 'docker exec -it $container_name bin/rspec $@'"
+docker exec -it $container_name bin/rspec $@


### PR DESCRIPTION
This reduces the amount of time it takes to run tests. Before the
majority of the time was spent waiting for rails to boot inside the
container. But no longer!

This changes script/test to start a web container and keep it running in
the background and just ssh into that container when running tests. Then
rails is only loaded once and everything is good.

To stop or restart the rails container use script/kill-spring

I used this exact same approach at work for many months it works very
well. TDD is awful when you to wait 10 seconds for rails to boot.

I have also gotten Docker for Mac working so the helper scripts no longer
deal with starting docker-machine. They should still work even if you
require docker-machine but you'll  have to start it and connect to it manually.
