### PR TITLE
Docker networking, and smaller images sizes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-FROM ruby:2.3.0
+FROM ruby:2.3.0-slim
 
 RUN apt-get update -qq && apt-get install -y build-essential
+RUN apt-get install -y git-core
 
 # for postgres
 RUN apt-get install -y libpq-dev

--- a/config/database.yml
+++ b/config/database.yml
@@ -11,8 +11,12 @@ default: &default
 
 development:
   <<: *default
+  host: 'db'
+  port: 5432
   database: cardistryio_development
 
 test:
   <<: *default
+  host: 'db'
+  port: 5432
   database: cardistryio_test

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -12,5 +12,5 @@ Rails.application.configure do
   config.assets.raise_runtime_errors = true
   config.action_view.raise_on_missing_translations = true
   config.action_mailer.default_url_options = { host: "localhost:3000" }
-  config.cache_store = :redis_store, ENV.fetch("REDIS_1_PORT")
+  config.cache_store = :redis_store
 end

--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -3,7 +3,7 @@ require 'resque/failure/redis'
 require 'resque/rollbar'
 
 if Rails.env.development?
-  Resque.redis = ENV.fetch("REDIS_1_PORT").gsub("tcp://", "")
+  Resque.redis = 'redis:6379'
 end
 
 Resque::Failure::Multiple.classes = [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,6 @@ box:
     - /box
 
 redis:
-  image: redis:2.6
+  image: redis:alpine
   ports:
     - "6379"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,48 +1,58 @@
-db:
-  image: postgres:9.4
-  ports:
-    - "5432"
+version: '2'
 
-app:
-  build: .
-  command: echo "Hello, world!"
-  volumes:
-    - .:/app
-  stdin_open: true
-  environment:
-    BUNDLE_PATH: "/box"
+services:
+  app:
+    build: .
+    command: echo "Hello, world!"
+    volumes:
+      - .:/app
+    stdin_open: true
+    environment:
+      BUNDLE_PATH: "/box"
 
-web:
-  extends:
-    service: app
-  command: bin/rails s -b 0.0.0.0 -p 3000
-  ports:
-    - "3000:3000"
-  links:
-    - db
-    - redis
-  volumes_from:
-    - box
+  web:
+    extends:
+      service: app
+    command: bin/rails s -b 0.0.0.0 -p 3000
+    ports:
+      - "3000:3000"
+    networks:
+      - cardistryio
+    volumes_from:
+      - box
 
-resque:
-  extends:
-    service: app
-  environment:
-    QUEUE: "*"
-    RAILS_ENV: development
-  command: bin/rake environment resque:work
-  links:
-    - db
-    - redis
-  volumes_from:
-    - box
+  resque:
+    extends:
+      service: app
+    environment:
+      QUEUE: "*"
+      RAILS_ENV: development
+    command: bin/rake environment resque:work
+    networks:
+      - cardistryio
+    volumes_from:
+      - box
 
-box:
-  image: busybox
-  volumes:
-    - /box
+  db:
+    image: postgres:9.4
+    ports:
+      - "5432"
+    networks:
+      - cardistryio
 
-redis:
-  image: redis:alpine
-  ports:
-    - "6379"
+  box:
+    image: busybox
+    volumes:
+      - /box
+
+  redis:
+    image: redis:alpine
+    ports:
+      - "6379"
+    networks:
+      - cardistryio
+
+    
+networks:
+  cardistryio:
+    driver: bridge

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -35,7 +35,7 @@ fi
 echo "---- Setting up environment variables"
 cp .sample.env .env
 
-
+docker-compose run -d db
 echo "---- Setting up databases"
 docker-compose run web bin/rake db:create RAILS_ENV=development
 docker-compose run web bin/rake db:create RAILS_ENV=test

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -20,6 +20,9 @@ fi
 echo "---- Building docker image"
 docker-compose build
 
+# Starts containers and creates network
+docker-compose up -d
+
 echo "---- Installing dependencies"
 docker-compose run web bundle install
 
@@ -31,6 +34,7 @@ fi
 
 echo "---- Setting up environment variables"
 cp .sample.env .env
+
 
 echo "---- Setting up databases"
 docker-compose run web bin/rake db:create RAILS_ENV=development


### PR DESCRIPTION
Changes:
- Docker linking has been replaced all for networking
- Configuration now uses services hostnames like 'db' and 'redis' to point to the containers
- Docker images now use smaller sizes

```
redis   latest       185.7 MB
redis   alpine       29.66 MB
ruby    latest       729.1 MB
ruby    2.3.0-slim   282.5 MB
```
