### PR TITLE
Only show a user's public videos on profile

### DIFF
--- a/app/views/users/_user_videos_cards.haml
+++ b/app/views/users/_user_videos_cards.haml
@@ -1,5 +1,5 @@
 %div.cards
-  - if @user.videos.present?
+  - if @user.videos.all_public.present?
     - @user.videos.each do |video|
       = link_to video, {:class => "card"} do
         %div.card-image

--- a/spec/features/videos/shows_video_on_profile_when_approved_spec.rb
+++ b/spec/features/videos/shows_video_on_profile_when_approved_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+feature "shows video on profile when approved" do
+  scenario "sees the video on profile" do
+    admin = create :user, admin: true
+    video = create :video, approved: false
+
+    visit user_path(video.user, as: admin)
+
+    expect(page).not_to have_content video.name
+
+    click_link "Approve videos"
+    click_button "Approve"
+
+    visit user_path(video.user, as: admin)
+    expect(page).to have_content video.name
+  end
+
+  scenario "doesn't show private videos on profile" do
+    admin = create :user, admin: true
+    video = create :video, approved: true, private: true
+
+    visit user_path(video.user, as: admin)
+
+    expect(page).not_to have_content video.name
+
+    video.update!(private: false)
+
+    visit user_path(video.user, as: admin)
+    expect(page).to have_content video.name
+  end
+end


### PR DESCRIPTION
I just noticed that danielkarlkvist had a video on his profile that hadn't been approved yet. Turns out we were showing all videos on user's profiles, not just the approved and public ones.

@bendobos I keep forgetting this too but we have to keep in mind that doing `Video.all.each` or `user.videos.each` will include unapproved and private videos.

Gonna merge this straight away.
