### PR TITLE
Add sprockets-es6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ gem "skylight"
 gem "stackprof"
 gem "title"
 gem "uglifier"
+gem "sprockets-es6"
 
 group :development do
   gem "spring"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,10 @@ GEM
     autoprefixer-rails (6.3.6)
       execjs
     awesome_print (1.6.1)
+    babel-source (5.8.35)
+    babel-transpiler (0.7.0)
+      babel-source (>= 4.0, < 6)
+      execjs (~> 2.0)
     bcrypt (3.1.11)
     bourbon (4.2.7)
       sass (~> 3.4)
@@ -363,6 +367,10 @@ GEM
     sprockets (3.6.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
+    sprockets-es6 (0.9.1)
+      babel-source (>= 5.8.11)
+      babel-transpiler
+      sprockets (>= 3.0.0)
     sprockets-rails (3.0.4)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
@@ -467,6 +475,7 @@ DEPENDENCIES
   skylight
   spring
   spring-commands-rspec
+  sprockets-es6
   stackprof
   timecop
   title

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,6 +9,7 @@ require "action_controller/railtie"
 require "action_mailer/railtie"
 require "action_view/railtie"
 require "sprockets/railtie"
+require "sprockets/es6"
 # require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems


### PR DESCRIPTION
I added [this gem](https://github.com/TannerRogalsky/sprockets-es6). Now both .js.coffee and .es6 files get transpiled. 

The author states that this is experimental but it works quite well.
There seems to be [a better alternative](https://github.com/fnando/babel-schmooze-sprockets) but it requires sprockets 4 which is still in beta and upgrading to it breaks a whole lot of stuff I wasn't able to figure out.

What do you think? Can we use this or should we pass on ES2015 until it is in a better state when used with rails? 
