### PR TITLE
Add DB_HOST and DB_PORT environment vars back

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,9 @@ services:
       - cardistryio
     volumes_from:
       - box
+    environment:
+      DB_HOST: db
+      DB_PORT: "5432"
 
   resque:
     extends:


### PR DESCRIPTION
This fixes this error that @bendobos got:

```
Bundle complete! 64 Gemfile dependencies, 164 gems now installed.
Bundled gems are installed into /box.
---- Setting up environment variables
cardistryio_db_run_2
---- Setting up databases
Starting cardistryio_box_1
DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super. (called from require at /usr/local/lib/ruby/gems/2.3.0/gems/bundler-1.11.2/lib/bundler/runtime.rb:77)
warning: parser/current is loading parser/ruby23, which recognizes
warning: 2.3.1-compliant syntax, but you are running 2.3.0.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
W, [2016-08-29T01:14:52.102879 #11]  WARN -- : [SKYLIGHT] [0.10.3] Running Skylight in development mode. No data will be reported until you deploy your app.
(To disable this message for all local apps, run `skylight disable_dev_warning`.)
Running via Spring preloader in process 17
could not connect to server: No such file or directory
           Is the server running locally and accepting
           connections on Unix domain socket "/var/run/postgresql/.s.PGSQL.5432"?
Couldn't create database for {"adapter"=>"postgresql", "encoding"=>"unicode", "pool"=>5, "database"=>"cardistryio_development"}
rake aborted!
PG::ConnectionBad: could not connect to server: No such file or directory
           Is the server running locally and accepting
           connections on Unix domain socket "/var/run/postgresql/.s.PGSQL.5432"?
/box/gems/activerecord-5.0.0.rc1/lib/active_record/connection_adapters/postgresql_adapter.rb:671:in `initialize'
/box/gems/activerecord-5.0.0.rc1/lib/active_record/connection_adapters/postgresql_adapter.rb:671:in `new'
/box/gems/activerecord-5.0.0.rc1/lib/active_record/connection_adapters/postgresql_adapter.rb:671:in `connect'
/box/gems/activerecord-5.0.0.rc1/lib/active_record/connection_adapters/postgresql_adapter.rb:217:in `initialize'
/box/gems/activerecord-5.0.0.rc1/lib/active_record/connection_adapters/postgresql_adapter.rb:37:in `new'
```
